### PR TITLE
feat: Add admin approval for athletes

### DIFF
--- a/app/dashboard/athletes/page.tsx
+++ b/app/dashboard/athletes/page.tsx
@@ -249,6 +249,7 @@ export default function AthletesPage() {
               onApprove={c.approve}
               onReject={() => openReject(a)}
               onWhatsApp={openWhatsAppApprove}
+              onAdminApprove={c.adminApprove}
             />
           ))
         )}

--- a/application/athletes/use-athletes-controller.ts
+++ b/application/athletes/use-athletes-controller.ts
@@ -162,6 +162,18 @@ export function useAthletesController(service: IAthleteService) {
     setFilters(baseFilters)
   }
 
+  async function adminApprove(id: string, isApproved: boolean) {
+    try {
+      await service.updateAdminApproval(id, isApproved)
+
+      const message = isApproved ? 'Atleta aprovado pelo admin!' : 'Atleta rejeitado pelo admin.'
+      toast({ title: `✅ ${message}`, description: 'O status final do atleta foi atualizado.', variant: 'success' })
+      refetchWithCacheClear()
+    } catch (e: any) {
+      toast({ title: '❌ Erro na operação', description: e.message || 'Tente novamente.', variant: 'destructive' })
+    }
+  }
+
   return {
     // dados base
     athletics,
@@ -186,6 +198,7 @@ export function useAthletesController(service: IAthleteService) {
     openApproveWhatsApp,
     buildRejectPreview,
     rejectAndNotify,
-    clearFilters
+    clearFilters,
+    adminApprove
   }
 }

--- a/domain/athletes/entities.ts
+++ b/domain/athletes/entities.ts
@@ -11,6 +11,7 @@ export interface Athlete {
   created_at: string
   cnh_cpf_document_url: string
   wpp_sent: boolean
+  admin_approved: boolean | null
   user: { name: string; email: string; cpf: string; phone: string; gender: string }
   athletic: { name: string }
   sports: Array<{ id: string; name: string; type: SportType }>

--- a/domain/athletes/ports.ts
+++ b/domain/athletes/ports.ts
@@ -3,4 +3,5 @@ import { Athlete } from './entities'
 export interface IAthleteService {
   updateStatus(athleteId: string, status: 'approved' | 'rejected'): Promise<void>
   updateWhatsAppStatus(athleteId: string, sent: boolean): Promise<void>
+  updateAdminApproval: (id: string, isApproved: boolean) => Promise<void>
 }

--- a/infrastructure/athletes/athleteService.supabase.ts
+++ b/infrastructure/athletes/athleteService.supabase.ts
@@ -7,5 +7,8 @@ export const AthleteServiceSupabase: IAthleteService = {
   },
   async updateWhatsAppStatus(id, sent) {
     await sdk.updateWhatsAppStatus(id, sent)
+  },
+  async updateAdminApproval(id, isApproved) {
+    await sdk.updateAdminApproval(id, isApproved)
   }
 }

--- a/ui/athletes/components/athlete-card.tsx
+++ b/ui/athletes/components/athlete-card.tsx
@@ -13,9 +13,18 @@ type Props = {
   onApprove: (id: string) => void
   onReject: (id: string) => void
   onWhatsApp: (a: Athlete) => void
+  onAdminApprove: (id: string, isApproved: boolean) => void
 }
 
-export default function AthleteCard({ athlete, userRole, onViewDoc, onApprove, onReject, onWhatsApp }: Props) {
+export default function AthleteCard({
+  athlete,
+  userRole,
+  onViewDoc,
+  onApprove,
+  onReject,
+  onWhatsApp,
+  onAdminApprove
+}: Props) {
   const hasPackage = !!athlete.athlete_packages?.length
   return (
     <Card className='hover:shadow-lg transition-all border border-gray-200 bg-white'>
@@ -55,6 +64,41 @@ export default function AthleteCard({ athlete, userRole, onViewDoc, onApprove, o
                   athlete.athlete_packages![0].package.price
                 )}
               </p>
+            </div>
+          </div>
+        )}
+
+        {userRole === 'admin' && athlete.status === 'approved' && (
+          <div className='bg-yellow-50 rounded-lg p-4 border border-yellow-200 space-y-3'>
+            <h4 className='font-semibold text-yellow-800'>Aprovação Final do Administrador</h4>
+            <div className='flex items-center justify-between'>
+              <div>
+                <p className='text-sm text-yellow-700'>
+                  {athlete.admin_approved === null && 'Aguardando avaliação.'}
+                  {athlete.admin_approved === true && 'O cadastro do atleta foi APROVADO.'}
+                  {athlete.admin_approved === false && 'O cadastro do atleta foi REJEITADO.'}
+                </p>
+              </div>
+              <div className='flex gap-3'>
+                <Button
+                  variant='outline'
+                  size='sm'
+                  onClick={() => onAdminApprove(athlete.id, false)}
+                  className='border-red-300 text-red-700'
+                  disabled={athlete.admin_approved === false}
+                >
+                  <UserX className='h-4 w-4 mr-2' /> Rejeitar
+                </Button>
+                <Button
+                  size='sm'
+                  variant='outline'
+                  className='border-green-300 text-green-700'
+                  onClick={() => onAdminApprove(athlete.id, true)}
+                  disabled={athlete.admin_approved === true}
+                >
+                  <UserCheck className='h-4 w-4 mr-2' /> Aprovar
+                </Button>
+              </div>
             </div>
           </div>
         )}


### PR DESCRIPTION
This feature introduces a new admin-specific approval step for athletes.

Key changes:
- Added a new `admin_approved` nullable boolean field to the `athletes` table to track the final approval status from an administrator.
- Updated the `Athlete` entity and related services to include the new field.
- Created a new backend service function `updateAdminApproval` with a role check to ensure only administrators can perform this action.
- Added a new section to the `AthleteCard` component on the frontend. This section is only visible to admin users when an athlete's status is 'approved'.
- This new UI allows admins to give a final approval or rejection, which is persisted to the database.