### PR TITLE
feat: Add capture attribute to file inputs to fix Android refresh issue

### DIFF
--- a/app/dashboard/profile/page.tsx
+++ b/app/dashboard/profile/page.tsx
@@ -200,6 +200,7 @@ const FileReplacementInterface = ({
             description={description}
             onFileChange={onFileChange}
             required={true}
+            capture={true}
           />
         </div>
 
@@ -1124,6 +1125,7 @@ export default function ProfilePage() {
                                   existingFileUrl={athlete?.cnh_cpf_document_url}
                                   onFileChange={handleDocumentChange}
                                   required={!athlete?.cnh_cpf_document_url}
+                                  capture={true}
                                 />
                               </div>
                             )}
@@ -1179,6 +1181,7 @@ export default function ProfilePage() {
                                   existingFileUrl={athlete?.enrollment_document_url}
                                   onFileChange={handleEnrollmentChange}
                                   required={!athlete?.enrollment_document_url}
+                                  capture={true}
                                 />
                               </div>
                             )}

--- a/components/ui/file-upload.tsx
+++ b/components/ui/file-upload.tsx
@@ -17,6 +17,7 @@ interface FileUploadProps {
   required?: boolean
   accept?: string
   maxSize?: number // in MB
+  capture?: boolean
 }
 
 export function FileUpload({
@@ -27,7 +28,8 @@ export function FileUpload({
   onFileChange,
   required = false,
   accept = 'image/*,.pdf',
-  maxSize = 5
+  maxSize = 5,
+  capture = false
 }: FileUploadProps) {
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
   const [dragActive, setDragActive] = useState(false)
@@ -155,6 +157,7 @@ export function FileUpload({
           onChange={handleInputChange}
           className='sr-only'
           aria-describedby={`${id}-description ${id}-error`}
+          capture={capture}
         />
 
         {selectedFile ? (


### PR DESCRIPTION
This change adds the `capture` attribute to the file input components used for document uploads in the athlete's profile page.

On some Android devices, selecting a file from the system file picker causes the browser to refresh, losing the application's state and preventing the file from being uploaded.

By adding the `capture` attribute, we hint to the browser to use a more direct file capture method (such as the camera or a lightweight file picker), which can prevent the page from being terminated and reloaded. This improves the user experience for file uploads on affected mobile devices.