### PR TITLE
feat: Enable reject button for athletic user when admin rejects

### DIFF
--- a/ui/athletes/components/athlete-card.tsx
+++ b/ui/athletes/components/athlete-card.tsx
@@ -133,26 +133,29 @@ export default function AthleteCard({
             )}
           </div>
 
-          {(userRole === 'admin' || userRole === 'athletic') && (athlete.status === 'sent' || athlete.status === 'rejected') && (
-            <div className='flex gap-3'>
-              <Button
-                variant='outline'
-                size='sm'
-                onClick={() => onReject(athlete.id)}
-                className='border-red-300 text-red-700'
-              >
-                <UserX className='h-4 w-4 mr-2' /> Rejeitar
-              </Button>
-              <Button
-                size='sm'
-                variant='outline'
-                className='border-green-300 hover:bg-green-700 text-black'
-                onClick={() => onApprove(athlete.id)}
-              >
-                <UserCheck className='h-4 w-4 mr-2' /> Aprovar
-              </Button>
-            </div>
-          )}
+          {(userRole === 'admin' || userRole === 'athletic') &&
+            (athlete.status === 'sent' || athlete.status === 'rejected' || athlete.admin_approved === false) && (
+              <div className='flex gap-3'>
+                <Button
+                  variant='outline'
+                  size='sm'
+                  onClick={() => onReject(athlete.id)}
+                  className='border-red-300 text-red-700'
+                >
+                  <UserX className='h-4 w-4 mr-2' /> Rejeitar
+                </Button>
+                {(athlete.status === 'sent' || athlete.status === 'rejected') && (
+                  <Button
+                    size='sm'
+                    variant='outline'
+                    className='border-green-300 hover:bg-green-700 text-black'
+                    onClick={() => onApprove(athlete.id)}
+                  >
+                    <UserCheck className='h-4 w-4 mr-2' /> Aprovar
+                  </Button>
+                )}
+              </div>
+            )}
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
This change modifies the `AthleteCard` component to allow an 'athletic' user to reject an athlete if the admin has previously rejected them (`admin_approved` is false).

Previously, the 'Reject' button was only visible when the athlete's status was 'sent' or 'rejected'. Now, it is also visible if `admin_approved` is `false`, giving the athletic association the opportunity to take action after an admin rejection.

The 'Approve' button's visibility remains unchanged and is not shown in this new state.